### PR TITLE
pom.xml updated to use jdk 1.7 in maven-compiler-plugin and ClusterStatus Metric Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The plugin has some options that you can configure in the elasticsearch.yml:
   * metrics.cloudwatch.aws.access_key and metrics.cloudwatch.aws.secret_key: AWS credentials of the account where the data will be posted in CloudWatch. No default values. If using IAM, it should have permission to CloudWatch PutMetricData.
   * metrics.cloudwatch.aws.region: Which region to use, of the AWS account. Default is us-east-1.
   * metrics.cloudwatch.frequency: How often to post stats. Default is "1m", every minute.
-  * metrics.cloudwatch.index_stats_enabled: To enable or disable stats per index. You don't want the explosion of metrics if you have too many indexes, such as for example with Logstash where there is an index per day. False by default.
-
+  * metrics.cloudwatch.index_shard_stats_enabled: To enable or disable stats per index per shard. You don't want the explosion of metrics if you have too many indexes, such as for example with Logstash where there is an index per day. False by default.
+  * metrics.cloudwatch.index_stats_enabled: Tracks failed shards, successful shards, total shards, docs deleted, docs total per index. default is false 
 We also set this option:
 
 network.publish_host: _ec2:publicDns_

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,18 @@
 	<build>
 		<plugins>
 			<!-- Add/Edit items in META-INF/MANIFEST.MF -->
+
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <showDeprecation>false</showDeprecation>
+		    <showWarnings>false</showWarnings>
+        	    <fork>true</fork>
+                </configuration>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/src/main/java/net/nineapps/elasticsearch/plugin/cloudwatch/CloudwatchPluginService.java
+++ b/src/main/java/net/nineapps/elasticsearch/plugin/cloudwatch/CloudwatchPluginService.java
@@ -49,6 +49,8 @@ public class CloudwatchPluginService extends AbstractLifecycleComponent<Cloudwat
     private AmazonCloudWatch cloudwatch;
     private final String clusterName;
     private boolean indexStatsEnabled;
+	private boolean osStatsEnabled;
+	private boolean jvmStatsEnabled;
 	
 	@Inject
 	public CloudwatchPluginService(Settings settings, Client client,
@@ -62,6 +64,9 @@ public class CloudwatchPluginService extends AbstractLifecycleComponent<Cloudwat
         awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
 
         indexStatsEnabled = settings.getAsBoolean("metrics.cloudwatch.index_stats_enabled", false);
+        osStatsEnabled = settings.getAsBoolean("metrics.cloudwatch.os_stats_enabled", false);
+        jvmStatsEnabled = settings.getAsBoolean("metrics.cloudwatch.jvm_stats_enabled", true);
+        
         String region = settings.get("metrics.cloudwatch.aws.region");
         logger.info("configured region is [{}]",region);
         cloudwatch = cloudwatchClient(region);
@@ -144,9 +149,13 @@ public class CloudwatchPluginService extends AbstractLifecycleComponent<Cloudwat
                 	// if it's still not there, we skip the node metrics this time
 //	                logger.info("node name is [{}]", nodeAddress);
 	                
-	    			sendOsStats(now, nodeStats, nodeAddress);
+                	if(osStatsEnabled){
+                		sendOsStats(now, nodeStats, nodeAddress);
+                	}
 
-	    			sendJVMStats(now, nodeStats, nodeAddress);
+                	if(jvmStatsEnabled){
+                		sendJVMStats(now, nodeStats, nodeAddress);
+                	}
 
 	    			sendDocsStats(now, nodeAddress, nodeIndicesStats);
 

--- a/src/main/java/net/nineapps/elasticsearch/plugin/cloudwatch/CloudwatchPluginService.java
+++ b/src/main/java/net/nineapps/elasticsearch/plugin/cloudwatch/CloudwatchPluginService.java
@@ -8,6 +8,7 @@ import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.client.Client;
@@ -113,8 +114,9 @@ public class CloudwatchPluginService extends AbstractLifecycleComponent<Cloudwat
 						
 						PutMetricDataRequest request = new PutMetricDataRequest();
 						request.setNamespace("9apps/Elasticsearch");
-
-						List<MetricDatum> data = Lists.newArrayList();
+						
+						List<MetricDatum> data = Lists.newArrayList(); 
+						data.add(clusterDatum(now, "ClusterStatus", (double) healthResponse.getStatus().value()));
 						data.add(clusterDatum(now, "NumberOfNodes", (double) healthResponse.getNumberOfNodes()));
 						data.add(clusterDatum(now, "NumberOfDataNodes", (double) healthResponse.getNumberOfDataNodes()));
 						data.add(clusterDatum(now, "ActivePrimaryShards", (double) healthResponse.getActivePrimaryShards()));

--- a/src/main/java/net/nineapps/elasticsearch/plugin/cloudwatch/CloudwatchPluginService.java
+++ b/src/main/java/net/nineapps/elasticsearch/plugin/cloudwatch/CloudwatchPluginService.java
@@ -262,12 +262,12 @@ public class CloudwatchPluginService extends AbstractLifecycleComponent<Cloudwat
 
 		private void sendIndexStats(final Date now, String nodeAddress) {
 			try {
-				PutMetricDataRequest request = new PutMetricDataRequest();
-				request.setNamespace("9apps/Elasticsearch");
-
 				List<MetricDatum> data = Lists.newArrayList();
 				List<IndexShard> indexShards = getIndexShards(indicesService);
 				for (IndexShard indexShard : indexShards) {
+					//Reset request per shard
+					PutMetricDataRequest request = new PutMetricDataRequest();
+					request.setNamespace("9apps/Elasticsearch");
 					
 					List<Dimension> dimensions = new ArrayList<Dimension>();
 				    dimensions.add(new Dimension().withName("IndexName").withValue(indexShard.shardId().index().name()));
@@ -290,9 +290,9 @@ public class CloudwatchPluginService extends AbstractLifecycleComponent<Cloudwat
 					request.setMetricData(data);
 					cloudwatch.putMetricData(request);
 				}
-	    		} catch (AmazonClientException e) {
+	    	} catch (AmazonClientException e) {
 	    			logger.error("Exception thrown by amazon while sending IndexStats", e);
-	    		}
+	    	}
 		}
 
 		private MetricDatum nodeDatum(final Date timestamp, String nodeAddress, 


### PR DESCRIPTION
The mvn clean package was failing with errors as below due to maven defaulting to jdk 1.3

"error: annotations are not supported in -source 1.3"

Also  ClusterStatus metric added to be able to setup cloudwatch alarms when cluster status goes RED (2)
