### PR TITLE
Move the creation of the MetricDatum List inside the shards loop.

### DIFF
--- a/src/main/java/net/nineapps/elasticsearch/plugin/cloudwatch/CloudwatchPluginService.java
+++ b/src/main/java/net/nineapps/elasticsearch/plugin/cloudwatch/CloudwatchPluginService.java
@@ -254,10 +254,10 @@ public class CloudwatchPluginService extends AbstractLifecycleComponent<Cloudwat
 				PutMetricDataRequest request = new PutMetricDataRequest();
 				request.setNamespace("9apps/Elasticsearch");
 
-				List<MetricDatum> data = Lists.newArrayList();
 				List<IndexShard> indexShards = getIndexShards(indicesService);
 				for (IndexShard indexShard : indexShards) {
 					
+					List<MetricDatum> data = Lists.newArrayList();
 					List<Dimension> dimensions = new ArrayList<Dimension>();
 				    dimensions.add(new Dimension().withName("IndexName").withValue(indexShard.shardId().index().name()));
 				    dimensions.add(new Dimension().withName("ShardId").withValue(indexShard.shardId().id() + ""));


### PR DESCRIPTION
A maximum of 20 items are allowed to be placed in the PutMetricData request.
When the List is created outside the loop, if there are more than 3 indexes then
the total number of datums will be > 20 and hence cause the PutMetricData
request to be rejected.

http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html
